### PR TITLE
fix: Disable floating buttons when no students are selected

### DIFF
--- a/src/components/pages/cepr-user-selection-page.js
+++ b/src/components/pages/cepr-user-selection-page.js
@@ -158,9 +158,15 @@ class CeprUserSelectionPage extends LocalizeMixin(LitElement) {
 	_renderFloatingButtons() {
 		return html`
 			<d2l-floating-buttons>
-				<d2l-button primary>Select Feedback</d2l-button>
+				<d2l-button
+					primary
+					?disabled=${!this.selectedUsers.size}
+				>
+					Select Feedback
+				</d2l-button>
 				<d2l-button-subtle
 					text="${this.localize('numberOfSelectedStudents', { selectedStudentsCount: this.selectedUsers.size })}"
+					?disabled=${!this.selectedUsers.size}
 				></d2l-button-subtle>
 			</d2l-floating-buttons>
 		`;


### PR DESCRIPTION
https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fuserstory%2F605978993416&fdp=true?fdp=true
![2021-05-27 - 1](https://user-images.githubusercontent.com/60618395/119887016-9b852980-bf01-11eb-9045-009e0c256e5e.gif)
