### PR TITLE
DE43912 - Properly divide upper/lower bounds by 100.

### DIFF
--- a/src/components/pages/cepr-grade-item-selection-page.js
+++ b/src/components/pages/cepr-grade-item-selection-page.js
@@ -138,8 +138,8 @@ class CeprGradeItemSelectionPage extends LocalizeMixin(LitElement) {
 
 			gradeItemQueries.push({
 				GradeItemId: gradeItemId,
-				LowerBounds: gradeItem.LowerBounds,
-				UpperBounds: gradeItem.UpperBounds
+				LowerBounds: gradeItem.LowerBounds / 100,
+				UpperBounds: gradeItem.UpperBounds / 100
 			});
 		});
 

--- a/src/services/user-service-demo.js
+++ b/src/services/user-service-demo.js
@@ -48,6 +48,10 @@ export class UserServiceDemo {
 		}
 	];
 
+	static async getAllUsers() {
+		return this.users;
+	}
+
 	static async getNumUsers() {
 		return this.users.length;
 	}


### PR DESCRIPTION
Also fixed a minor console error on the demo page.

[DE43912](https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fdefect%2F601486613523&fdp=true?fdp=true)