### PR TITLE
Switch to incremental release - US129128

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version: '14.x'
-      - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+      - name: Incremental Release
+        id: incremental-release
+        uses: BrightspaceUI/actions/incremental-release@master
         with:
+          DEFAULT_INCREMENT: patch
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
-          NPM: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -92,24 +92,11 @@ npm start
 
 ## Versioning & Releasing
 
-> TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...
+All version changes should obey [semantic versioning](https://semver.org/) rules.
 
-The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+By default, a patch release will be created anytime code is merged into master. To specify the type of release include either `[increment major]`, `[increment minor]` or `[increment patch]` in your merge commit message to automatically increment the `package.json` version, create a tag, and trigger a deployment to NPM.
 
-### Version Changes
-
-All version changes should obey [semantic versioning](https://semver.org/) rules:
-1. **MAJOR** version when you make incompatible API changes,
-2. **MINOR** version when you add functionality in a backwards compatible manner, and
-3. **PATCH** version when you make backwards compatible bug fixes.
-
-The next version number will be determined from the commit messages since the previous release. Our semantic-release configuration uses the [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) when analyzing commits:
-* Commits which are prefixed with `fix:` or `perf:` will trigger a `patch` release. Example: `fix: validate input before using`
-* Commits which are prefixed with `feat:` will trigger a `minor` release. Example: `feat: add toggle() method`
-* To trigger a MAJOR release, include `BREAKING CHANGE:` with a space or two newlines in the footer of the commit message
-* Other suggested prefixes which will **NOT** trigger a release: `build:`, `ci:`, `docs:`, `style:`, `refactor:` and `test:`. Example: `docs: adding README for new component`
-
-To revert a change, add the `revert:` prefix to the original commit message. This will cause the reverted change to be omitted from the release notes. Example: `revert: fix: validate input before using`.
+If you want to bypass and skip a release, include `[skip release]` in your merge commit message.
 
 ### Releases
 


### PR DESCRIPTION
- Switch the Custom Early Progress Report tool to use incremental-release instead of semantic-release for releases
- Update README to reflect the change to incremental-release
- Set up incremental-release to default to create patch releases if no release is specified

https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fuserstory%2F601652849933