### PR TITLE
US129025-Fixing Student count on Selected Grade

### DIFF
--- a/src/components/pages/cepr-user-selection-page.js
+++ b/src/components/pages/cepr-user-selection-page.js
@@ -281,7 +281,7 @@ class CeprUserSelectionPage extends LocalizeMixin(LitElement) {
 			const gradeItemId = gradeItem.GradeItemId;
 			this.gradedStudentCount.set(gradeItemId, studentCount);
 			this.users.map((student) => {
-				if (student.Grades[gradeItemId]) {
+				if (!isNaN(student.Grades[gradeItemId])) {
 					this.gradedStudentCount.set(gradeItemId, ++studentCount);
 				}
 			});


### PR DESCRIPTION
https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fuserstory%2F601479942453
When a student is graded 0% the {x} Students in the Selected Grade section shows wrong count of student.
![img](https://user-images.githubusercontent.com/62559837/122988010-435e0d80-d36f-11eb-91ed-b0caeaf34a02.png)
 