### PR TITLE
DE44193 - Use allUsers instead of users to count students per grade item

### DIFF
--- a/src/components/pages/cepr-user-selection-page.js
+++ b/src/components/pages/cepr-user-selection-page.js
@@ -280,7 +280,7 @@ class CeprUserSelectionPage extends LocalizeMixin(LitElement) {
 			let studentCount = 0;
 			const gradeItemId = gradeItem.GradeItemId;
 			this.gradedStudentCount.set(gradeItemId, studentCount);
-			this.users.map((student) => {
+			this.allUsers.map((student) => {
 				if (!isNaN(student.Grades[gradeItemId])) {
 					this.gradedStudentCount.set(gradeItemId, ++studentCount);
 				}


### PR DESCRIPTION
[DE44193](https://rally1.rallydev.com/#/431372673576d/iterationstatus?Name=%5BUArizona%5D%20Step%202%20Grade%20Item%20List%20Incorrect%20Student%20Count&Priority=Normal&Project=%2Fproject%2F431372673576&Requirement=%2Fhierarchicalrequirement%2F601479942453&Severity=Cosmetic&detail=%2Fdefect%2F602626162551&iteration=u&parentRef=%2Fhierarchicalrequirement%2F601479942453&rankTo=BOTTOM&fdp=true?fdp=true)

![2021-06-28 1](https://user-images.githubusercontent.com/60618395/123682814-7f82e980-d819-11eb-8a0e-62be9fba9568.gif)
