### PR TITLE
Fix langterm capitalization in preview dialog

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -16,7 +16,7 @@ export default {
 	"cancelButton": "Cancel",
 	"closeButton": "Close",
 	"doneButton": "Done",
-	"continueToSalesForceButton": "Continue to SalesForce",
+	"continueToSalesforceButton": "Continue to Salesforce",
 	"gradeItemTableHeader": "Grade Item",
 	"minGradeTableHeader": "Minimum Grade",
 	"maxGradeTableHeader": "Maximum Grade",

--- a/src/components/dialogs/cepr-student-grades-summary-dialog.js
+++ b/src/components/dialogs/cepr-student-grades-summary-dialog.js
@@ -110,9 +110,9 @@ class CeprStudentGradesSummaryDialog extends LocalizeMixin(LitElement) {
 			<d2l-button
 				slot="footer"
 				primary
-				@click=${this._handleContinueToSalesForce}
+				@click=${this._handleContinueToSalesforce}
 			>
-				${this.localize('continueToSalesForceButton')}
+				${this.localize('continueToSalesforceButton')}
 			</d2l-button>
 			<d2l-button slot="footer" data-dialog-action>
 				${this.localize('closeButton')}
@@ -168,7 +168,7 @@ class CeprStudentGradesSummaryDialog extends LocalizeMixin(LitElement) {
 		});
 	}
 
-	_handleContinueToSalesForce() {
+	_handleContinueToSalesforce() {
 		this.dispatchEvent(new CustomEvent('continue-to-salesforce'));
 	}
 


### PR DESCRIPTION
`SalesForce` => `Salesforce`
We need to match Salesforce's spelling:
![langterm-capitalization-needs-fix](https://user-images.githubusercontent.com/59580355/125321524-c76e3a00-e30a-11eb-900c-397bc78a9bf1.png)
Rally: [US126765](https://rally1.rallydev.com/#/431372673576d/iterationstatus?detail=%2Fuserstory%2F519547051560&fdp=true&fdp=true?fdp=true): [UArizona] Progress Report - End to End Testing
