### PR TITLE
US135824 Lit 2 Migration - Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.1",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@open-wc/testing-karma": "^4",
     "@webcomponents/webcomponentsjs": "^2",
     "deepmerge": "^4",
@@ -41,10 +41,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui-labs/pagination": "^1.0.5",
-    "@brightspace-ui-labs/wizard": "^1.3.2",
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui-labs/pagination": "^2",
+    "@brightspace-ui-labs/wizard": "^2",
+    "@brightspace-ui/core": "^2",
+    "lit-element": "^3",
+    "lit-html": "^2"
   },
   "version": "1.3.20"
 }


### PR DESCRIPTION
[US135824 ](https://rally1.rallydev.com/#/431372673576ud/iterationstatus?detail=%2Fuserstory%2F623965296985)

This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**. 

Breaking change checklist:  
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used) 
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement  
- [x] Remove Dependabot Lit rules 
- [x] Bump any dependencies to their Lit 2 versions 
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers 
- [x] Backwards-compatible changes merged: https://github.com/Brightspace/custom-early-progress-report/pull/46

Renamed API's: 
- [x] `UpdatingElement` -> `ReactiveElement` 
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators) 
- [x] `static getStyles()` -> `static finalizeStyles(styles)` 
- [x] `_getUpdateComplete()` -> `getUpdateComplete()` 
- [x] `NodePart` -> `ChildPart` 

Testing checklist:  
- [x] CI/ unit tests pass 
- [x] Local testing on demo pages 
- [x] Testing component in the LMS 

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi. 